### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Arduino
 maintainer=Gene Reeves
 sentence=Streaming C++-style Output with Operator <<
 paragraph=Streaming C++-style Output with Operator (orignially from Mikal Hart http://arduiniana.org/libraries/streaming/)<<
-category=Language
+category=Data Processing
 url=https://github.com/geneReeves/ArduinoStreaming
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Language' in library ArduinoStreaming is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format